### PR TITLE
Remove all control characters from abstract

### DIFF
--- a/src/classes/Pergamum.php
+++ b/src/classes/Pergamum.php
@@ -71,10 +71,8 @@ class Pergamum implements Repository {
 					//Abstract comes from another database field
 					if ($camposMarc[$j]["paragrafo"] == self::MARC_PARAGRAFO_ABSTRACT) {
 						$value = html_entity_decode($camposMarc[$j]["texto_descricao"]);
-						//remove CR/LF from abstract
-						$value = str_replace(chr(13), '', $value);
-						$value = str_replace(chr(10), '', $value);
-						$value = str_replace("", '', $value);
+						//remove control characters from abstract
+						$value = preg_replace('/[[:cntrl:]]/', '', $value);
 					} else {
 						$value = html_entity_decode($camposMarc[$j]["descricao"]);
 					}

--- a/src/classes/Pergamum.php
+++ b/src/classes/Pergamum.php
@@ -72,7 +72,7 @@ class Pergamum implements Repository {
 					if ($camposMarc[$j]["paragrafo"] == self::MARC_PARAGRAFO_ABSTRACT) {
 						$value = html_entity_decode($camposMarc[$j]["texto_descricao"]);
 						//remove control characters from abstract
-						$value = preg_replace('/[[:cntrl:]]/', '', $value);
+						$value = preg_replace('/[[:cntrl:]]/', ' ', $value);
 					} else {
 						$value = html_entity_decode($camposMarc[$j]["descricao"]);
 					}


### PR DESCRIPTION
When dealing with MARC data, I have seem all kind of junk chars (us, rs, gs, fs, esc, dc2, stx, soh, etx, nak, etb, sub, si). So, let's block them from entering in DSpace.

Source:
https://stackoverflow.com/questions/1497885